### PR TITLE
SAS-4799 - plug smoke-tests into PR checks

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -104,6 +104,54 @@ jobs:
         if: always()
         run: docker compose down -v
 
+  smoke:
+    needs: test
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    env:
+      COMPOSE_FILES: -f docker-compose.yml -f docker-compose.smoke-test.yml
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Cache Docker layers
+        uses: actions/cache@v4
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-buildx-smoke-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-buildx-smoke-
+            ${{ runner.os }}-buildx-
+
+      - name: Build Docker images
+        run: docker compose $COMPOSE_FILES build --pull
+        env:
+          DOCKER_BUILDKIT: 1
+          COMPOSE_DOCKER_CLI_BUILD: 1
+
+      - name: Create required directories
+        run: |
+          mkdir -p localdata
+          chmod 777 localdata
+
+      - name: Start services
+        run: docker compose $COMPOSE_FILES up -d web
+
+      - name: Run smoke tests
+        run: docker compose $COMPOSE_FILES run --rm smoke
+
+      - name: Show logs on failure
+        if: failure()
+        run: docker compose $COMPOSE_FILES logs web
+
+      - name: Cleanup
+        if: always()
+        run: docker compose $COMPOSE_FILES down -v
+
   e2e:
     needs: test
     runs-on: ubuntu-latest

--- a/docker-compose.smoke-test.yml
+++ b/docker-compose.smoke-test.yml
@@ -2,3 +2,23 @@ services:
   web:
     ports:
       - "3000:3000"
+  smoke:
+    image: node:20-alpine
+    working_dir: /smoke-tests
+    volumes:
+      - ./smoke-tests:/smoke-tests
+      - smoke_node_modules:/smoke-tests/node_modules
+    environment:
+      SMOKE_TEST_BASE_URL: http://web:3000
+      SMOKE_TEST_APP_ID: devapp
+      SMOKE_TEST_KEY_ID: devkey
+      SMOKE_TEST_KEY_SECRET: devsecret
+      SMOKE_TEST_ENVIRONMENT: local
+      SMOKE_TEST_ADMIN_USERNAME: admin
+      SMOKE_TEST_ADMIN_PASSWORD: password
+    command: sh -c "npm ci && npm test"
+    depends_on:
+      - web
+
+volumes:
+  smoke_node_modules:

--- a/docker-compose.smoke-test.yml
+++ b/docker-compose.smoke-test.yml
@@ -1,5 +1,11 @@
 services:
   web:
+    build:
+      context: .
+      args:
+        prunedev: 'false'
+    volumes:
+      - './localdata:/usr/src/app/localdata'
     ports:
       - "3000:3000"
   smoke:

--- a/smoke-tests/src/lib/readiness.ts
+++ b/smoke-tests/src/lib/readiness.ts
@@ -1,7 +1,9 @@
 import { http } from "./http";
 
+const defaultMaxAttempts = Number(process.env.SMOKE_TEST_HOOK_TIMEOUT_SECONDS) || 60;
+
 export async function waitForReady(
-  maxAttempts = 60,
+  maxAttempts = defaultMaxAttempts,
   intervalMs = 1000,
 ): Promise<void> {
   for (let attempt = 1; attempt <= maxAttempts; attempt++) {

--- a/smoke-tests/src/lib/readiness.ts
+++ b/smoke-tests/src/lib/readiness.ts
@@ -1,13 +1,15 @@
 import { http } from "./http";
 
 export async function waitForReady(
-  maxAttempts = 30,
+  maxAttempts = 60,
   intervalMs = 1000,
 ): Promise<void> {
   for (let attempt = 1; attempt <= maxAttempts; attempt++) {
     try {
       const res = await http.get("/health_check.json");
-      if (res.status === 200) return;
+      if (res.status === 200) {
+        return;
+      }
     } catch {
       // Connection refused, etc. — keep trying.
     }

--- a/smoke-tests/src/tests/health-check.test.ts
+++ b/smoke-tests/src/tests/health-check.test.ts
@@ -6,6 +6,11 @@ beforeAll(async () => {
 });
 
 describe("Health Check", () => {
+  // TODO: remove after verifying CI pipeline fails on assertion errors
+  it("should fail intentionally", () => {
+    expect(1).toBe(2);
+  });
+
   it("should return 200 with version info", async () => {
     const res = await http.get("/health_check.json");
 

--- a/smoke-tests/src/tests/health-check.test.ts
+++ b/smoke-tests/src/tests/health-check.test.ts
@@ -6,11 +6,6 @@ beforeAll(async () => {
 });
 
 describe("Health Check", () => {
-  // TODO: remove after verifying CI pipeline fails on assertion errors
-  it("should fail intentionally", () => {
-    expect(1).toBe(2);
-  });
-
   it("should return 200 with version info", async () => {
     const res = await http.get("/health_check.json");
 

--- a/smoke-tests/vitest.config.ts
+++ b/smoke-tests/vitest.config.ts
@@ -4,7 +4,7 @@ export default defineConfig({
   test: {
     globals: true,
     testTimeout: 30_000,
-    hookTimeout: 30_000,
+    hookTimeout: 60_000,
     setupFiles: ["dotenv/config"],
   },
 });

--- a/smoke-tests/vitest.config.ts
+++ b/smoke-tests/vitest.config.ts
@@ -1,10 +1,12 @@
 import { defineConfig } from "vitest/config";
 
+const hookTimeoutSeconds = Number(process.env.SMOKE_TEST_HOOK_TIMEOUT_SECONDS) || 60;
+
 export default defineConfig({
   test: {
     globals: true,
     testTimeout: 30_000,
-    hookTimeout: 60_000,
+    hookTimeout: hookTimeoutSeconds * 1000,
     setupFiles: ["dotenv/config"],
   },
 });


### PR DESCRIPTION
Plug smoke-tests into PR checks in 'local' mode as an extra layer of integration tests.

The smoke-tests run in parallel with the e2e tests for faster execution.

Example executions:

- failure: https://github.com/instructure/pandapush/actions/runs/24126383544/job/70392785806?pr=76
- success: https://github.com/instructure/pandapush/actions/runs/24132685390/job/70413721587?pr=76

refs: SAS-4799